### PR TITLE
register_push add a option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,8 @@
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
+.idea/
+
+pubsub_cli
+
 dist

--- a/cmd/register_push.go
+++ b/cmd/register_push.go
@@ -8,12 +8,16 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"io"
+	"os"
 	"strconv"
 	"time"
 )
 
+const ackDeadlineFlagName = "ack-deadline"
+
 // newRegisterPushCmd returns the command to register an endpoint for subscribing
 func newRegisterPushCmd(out io.Writer) *cobra.Command {
+	ackDeadlineDefault := os.Getenv("PUBSUB_ACK_DEADLINE")
 	command := &cobra.Command{
 		Use:     "register_push TOPIC_ID ENDPOINT",
 		Short:   "register Pub/Sub push endpoint",
@@ -26,6 +30,7 @@ func newRegisterPushCmd(out io.Writer) *cobra.Command {
 			endpoint := args[1]
 			ackDeadline, err := cmd.Flags().GetString("ack-deadline")
 			ackDeadlineNum, err := strconv.ParseInt(ackDeadline, 10, 64)
+			ackDeadlineSecond := time.Duration(ackDeadlineNum) * time.Second
 			projectID, err := cmd.Flags().GetString("project")
 			emulatorHost, err := cmd.Flags().GetString("host")
 			gcpCredentialFilePath, err := cmd.Flags().GetString("cred-file")
@@ -34,15 +39,16 @@ func newRegisterPushCmd(out io.Writer) *cobra.Command {
 			if err != nil {
 				return errors.Wrap(err, "initialize pubsub client")
 			}
-			return registerPush(cmd.Context(), out, pubsubClient, topicID, endpoint, ackDeadlineNum)
+			return registerPush(cmd.Context(), out, pubsubClient, topicID, endpoint, ackDeadlineSecond)
 		},
 	}
 	command.SetOut(out)
+	command.PersistentFlags().StringVarP(&ackDeadlineDefault, ackDeadlineFlagName, "a", ackDeadlineDefault, "pubsub ack deadline(unit seconds)")
 	return command
 }
 
 // registerPush registers new push endpoint
-func registerPush(ctx context.Context, out io.Writer, pubsubClient *pkg.PubSubClient, topicID, endpoint string, ackDeadline int64) error {
+func registerPush(ctx context.Context, out io.Writer, pubsubClient *pkg.PubSubClient, topicID, endpoint string, ackDeadline time.Duration) error {
 	topic, err := pubsubClient.FindOrCreateTopic(ctx, topicID)
 	if err != nil {
 		return errors.Wrapf(err, "[error]find or create topic %s", topicID)
@@ -51,7 +57,7 @@ func registerPush(ctx context.Context, out io.Writer, pubsubClient *pkg.PubSubCl
 	_, _ = colorstring.Fprintf(out, "[start] registering push endpoint for %s...\n", topic.String())
 	subscriptionConfig := pubsub.SubscriptionConfig{
 		Topic:            topic,
-		AckDeadline: time.Duration(ackDeadline) * time.Second,
+		AckDeadline: ackDeadline,
 		ExpirationPolicy: 24 * time.Hour,
 		PushConfig: pubsub.PushConfig{
 			Endpoint:             endpoint,

--- a/cmd/register_push.go
+++ b/cmd/register_push.go
@@ -24,7 +24,7 @@ func newRegisterPushCmd(out io.Writer) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			topicID := args[0]
 			endpoint := args[1]
-			ackDeadline, err := cmd.Flags().GetString("timeout")
+			ackDeadline, err := cmd.Flags().GetString("ack-deadline")
 			ackDeadlineNum, err := strconv.ParseInt(ackDeadline, 10, 64)
 			projectID, err := cmd.Flags().GetString("project")
 			emulatorHost, err := cmd.Flags().GetString("host")
@@ -52,10 +52,6 @@ func registerPush(ctx context.Context, out io.Writer, pubsubClient *pkg.PubSubCl
 	subscriptionConfig := pubsub.SubscriptionConfig{
 		Topic:            topic,
 		AckDeadline: time.Duration(ackDeadline) * time.Second,
-		//RetryPolicy: &pubsub.RetryPolicy{
-		//	MinimumBackoff: time.Duration(ackDeadline) * time.Second,
-		//	MaximumBackoff: time.Duration(ackDeadline) * time.Second,
-		//},
 		ExpirationPolicy: 24 * time.Hour,
 		PushConfig: pubsub.PushConfig{
 			Endpoint:             endpoint,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,7 +12,7 @@ const projectFlagName = "project"
 const hostFlagName = "host"
 const credFileFlagName = "cred-file"
 const createTopicIfNotExistFlagName = "create-if-not-exist"
-const ackDeadline = "timeout"
+const ackDeadlineFlagName = "ack-deadline"
 
 var version string
 
@@ -37,12 +37,12 @@ func newRootCmd(out io.Writer) *cobra.Command {
 	projectID := os.Getenv("GCP_PROJECT_ID")
 	emulatorHost := os.Getenv("PUBSUB_EMULATOR_HOST")
 	gcpCredentialFilePath := os.Getenv("GOOGLE_APPLICATION_CREDENTIALS")
-	timeout := os.Getenv("PUBSUB_RETRY_TIMEOUT")
+	ackDeadline := os.Getenv("PUBSUB_ACK_DEADLINE")
 	rootCmd.PersistentFlags().Bool("help", false, fmt.Sprintf("help for %s", rootCmd.Name()))
 	rootCmd.PersistentFlags().StringVarP(&projectID, projectFlagName, "p", projectID, "gcp project id (You can also set 'GCP_PROJECT_ID' to env variable)")
 	rootCmd.PersistentFlags().StringVarP(&emulatorHost, hostFlagName, "h", emulatorHost, "emulator host (You can also set 'PUBSUB_EMULATOR_HOST' to env variable)")
 	rootCmd.PersistentFlags().StringVarP(&gcpCredentialFilePath, credFileFlagName, "c", gcpCredentialFilePath, "gcp credential file path (You can also set 'GOOGLE_APPLICATION_CREDENTIALS' to env variable)")
-	rootCmd.PersistentFlags().StringVarP(&timeout, ackDeadline, "t", timeout, "pubsub Retry timeout")
+	rootCmd.PersistentFlags().StringVarP(&ackDeadline, ackDeadlineFlagName, "t", ackDeadline, "pubsub ack deadline(unit seconds)")
 
 	rootCmd.AddCommand(
 		newPublishCmd(out),

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,7 +12,6 @@ const projectFlagName = "project"
 const hostFlagName = "host"
 const credFileFlagName = "cred-file"
 const createTopicIfNotExistFlagName = "create-if-not-exist"
-const ackDeadlineFlagName = "ack-deadline"
 
 var version string
 
@@ -37,13 +36,10 @@ func newRootCmd(out io.Writer) *cobra.Command {
 	projectID := os.Getenv("GCP_PROJECT_ID")
 	emulatorHost := os.Getenv("PUBSUB_EMULATOR_HOST")
 	gcpCredentialFilePath := os.Getenv("GOOGLE_APPLICATION_CREDENTIALS")
-	ackDeadline := os.Getenv("PUBSUB_ACK_DEADLINE")
 	rootCmd.PersistentFlags().Bool("help", false, fmt.Sprintf("help for %s", rootCmd.Name()))
 	rootCmd.PersistentFlags().StringVarP(&projectID, projectFlagName, "p", projectID, "gcp project id (You can also set 'GCP_PROJECT_ID' to env variable)")
 	rootCmd.PersistentFlags().StringVarP(&emulatorHost, hostFlagName, "h", emulatorHost, "emulator host (You can also set 'PUBSUB_EMULATOR_HOST' to env variable)")
 	rootCmd.PersistentFlags().StringVarP(&gcpCredentialFilePath, credFileFlagName, "c", gcpCredentialFilePath, "gcp credential file path (You can also set 'GOOGLE_APPLICATION_CREDENTIALS' to env variable)")
-	rootCmd.PersistentFlags().StringVarP(&ackDeadline, ackDeadlineFlagName, "t", ackDeadline, "pubsub ack deadline(unit seconds)")
-
 	rootCmd.AddCommand(
 		newPublishCmd(out),
 		newSubscribeCmd(out),

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,17 +2,17 @@ package cmd
 
 import (
 	"fmt"
-	"io"
-	"os"
-
 	"github.com/mitchellh/colorstring"
 	"github.com/spf13/cobra"
+	"io"
+	"os"
 )
 
 const projectFlagName = "project"
 const hostFlagName = "host"
 const credFileFlagName = "cred-file"
 const createTopicIfNotExistFlagName = "create-if-not-exist"
+const ackDeadline = "timeout"
 
 var version string
 
@@ -37,10 +37,12 @@ func newRootCmd(out io.Writer) *cobra.Command {
 	projectID := os.Getenv("GCP_PROJECT_ID")
 	emulatorHost := os.Getenv("PUBSUB_EMULATOR_HOST")
 	gcpCredentialFilePath := os.Getenv("GOOGLE_APPLICATION_CREDENTIALS")
+	timeout := os.Getenv("PUBSUB_RETRY_TIMEOUT")
 	rootCmd.PersistentFlags().Bool("help", false, fmt.Sprintf("help for %s", rootCmd.Name()))
 	rootCmd.PersistentFlags().StringVarP(&projectID, projectFlagName, "p", projectID, "gcp project id (You can also set 'GCP_PROJECT_ID' to env variable)")
 	rootCmd.PersistentFlags().StringVarP(&emulatorHost, hostFlagName, "h", emulatorHost, "emulator host (You can also set 'PUBSUB_EMULATOR_HOST' to env variable)")
 	rootCmd.PersistentFlags().StringVarP(&gcpCredentialFilePath, credFileFlagName, "c", gcpCredentialFilePath, "gcp credential file path (You can also set 'GOOGLE_APPLICATION_CREDENTIALS' to env variable)")
+	rootCmd.PersistentFlags().StringVarP(&timeout, ackDeadline, "t", timeout, "pubsub Retry timeout")
 
 	rootCmd.AddCommand(
 		newPublishCmd(out),


### PR DESCRIPTION
The ack-deadline option was added to the register_push command because the local test program took a long time to execute and needed to change the ackDeadline option value